### PR TITLE
added parameter to fetch claim totals in gets of submissions

### DIFF
--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/controller/SubmissionController.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/controller/SubmissionController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.laa.claimforpayment.exception.SubmissionNotFoundException;
 import uk.gov.justice.laa.claimforpayment.model.Submission;
@@ -58,10 +59,11 @@ public class SubmissionController {
   @GetMapping("/{id}")
   public ResponseEntity<Submission> getSubmission(
       @Parameter(description = "ID of the submission to retrieve", required = true) @PathVariable
-          UUID id) {
+          UUID id,
+      @RequestParam(name = "includeTotals", defaultValue = "false") boolean includeTotals) {
 
     log.debug("Fetching submission with ID: {}", id);
-    Submission submission = claimService.getSubmission(id);
+    Submission submission = claimService.getSubmission(id, includeTotals);
     return ResponseEntity.ok(submission);
   }
 
@@ -84,12 +86,14 @@ public class SubmissionController {
       })
   @GetMapping
   public ResponseEntity<List<Submission>> getAllSubmissionsForProvider(
-      @AuthenticationPrincipal ProviderUserPrincipal principal) {
+      @AuthenticationPrincipal ProviderUserPrincipal principal,
+      @RequestParam(name = "includeTotals", defaultValue = "false") boolean includeTotals) {
 
     UUID providerUserId = principal.providerUserId();
     log.debug("Fetching all submissions for provider user " + providerUserId);
 
-    List<Submission> submissions = claimService.getAllSubmissionsForProvider(providerUserId);
+    List<Submission> submissions =
+        claimService.getAllSubmissionsForProvider(providerUserId, includeTotals);
     return ResponseEntity.ok(submissions);
   }
 

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/model/Submission.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/model/Submission.java
@@ -1,8 +1,10 @@
 package uk.gov.justice.laa.claimforpayment.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -13,9 +15,10 @@ import lombok.NoArgsConstructor;
 
 /** Submission – wraps a batch of claims along with submission metadata. */
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "Submission", description = "A submission containing multiple claims")
 public class Submission implements Serializable {
 
@@ -59,4 +62,7 @@ public class Submission implements Serializable {
   @Schema(description = "List of claims in this submission")
   @JsonProperty("claims")
   private List<Claim> claims;
+
+  @Schema(description = "Total amount claimed in this submission")
+  BigDecimal totalClaimed;
 }

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/repository/SubmissionRepository.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/repository/SubmissionRepository.java
@@ -1,8 +1,11 @@
 package uk.gov.justice.laa.claimforpayment.repository;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.laa.claimforpayment.entity.SubmissionEntity;
 
@@ -12,4 +15,24 @@ public interface SubmissionRepository extends JpaRepository<SubmissionEntity, UU
 
   // Find submissions by the provider user
   List<SubmissionEntity> findByProviderUserId(UUID providerUserId);
+
+  // Include claim value totals for all
+  @Query(
+      """
+          SELECT s.id, COALESCE(SUM(c.claimed), 0)
+          FROM SubmissionEntity s
+          LEFT JOIN s.claims c
+          GROUP BY s.id
+      """)
+  List<Object[]> findSubmissionTotals();
+
+  // include claim value totals for one submission
+  @Query(
+      """
+          SELECT COALESCE(SUM(c.claimed), 0)
+          FROM SubmissionEntity s
+          LEFT JOIN s.claims c
+          WHERE s.id = :id
+      """)
+  BigDecimal findSubmissionTotalById(@Param("id") UUID id);
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CLAIM-263)

Added an optional parameter to get submissions and get a submission by id which returns the total amount claimed by all claims belonging to that submission.

Had to implement this in the database repository and service layer, this calculates totals in sql by doing 2 queries. Other options might be a materialised view in the database but that will be up to the civil claims API. Can extend this later to include actual amount paid etc.

use

`?includeTotals=true`

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
