### PR TITLE
Added version/retry to draft claim service patch methods

### DIFF
--- a/claim-for-payment-service/build.gradle
+++ b/claim-for-payment-service/build.gradle
@@ -210,6 +210,9 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
 
+    implementation 'org.springframework.retry:spring-retry:2.0.13'
+    implementation 'org.springframework:spring-aspects'
+
     implementation "tools.jackson.core:jackson-databind:${rootProject.ext.jacksonDatabindVersion}"
 
 

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/config/ExternalApiClientsConfig.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/config/ExternalApiClientsConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +22,7 @@ import uk.gov.justice.laa.claimforpayment.config.auth.TokenProvider;
 /** Spring config for external API clients. */
 @Configuration
 @Slf4j
+@EnableRetry
 @SuppressWarnings({"checkstyle:LocalVariableName", "checkstyle:AbbreviationAsWordInName"})
 public class ExternalApiClientsConfig {
 

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/mapper/CivilClaimMapper.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/mapper/CivilClaimMapper.java
@@ -1,15 +1,16 @@
 package uk.gov.justice.laa.claimforpayment.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import uk.gov.justice.laa.claimforpayment.civilclaims.model.CivilClaim;
 import uk.gov.justice.laa.claimforpayment.model.Claim;
 
 /** the mapper between civil claims and api claims. */
 @Mapper(
     componentModel = "spring",
-    uses = {CivilClaimEvidenceMapper.class}
-)
+    uses = {CivilClaimEvidenceMapper.class})
 public interface CivilClaimMapper {
+  @Mapping(target = "version", ignore = true)
   Claim toClaim(CivilClaim claim);
 
   CivilClaim toCivilClaim(Claim claim);

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/model/Claim.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/model/Claim.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.claimforpayment.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -26,6 +27,9 @@ public class Claim implements Serializable {
   @Schema(name = "id", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("id")
   private UUID id;
+
+  @JsonIgnore
+  private Long version;
 
   @Schema(description = "cost type")
   @JsonProperty("costType")

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimService.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimService.java
@@ -111,10 +111,12 @@ public class DraftClaimService implements ClaimServiceInterface {
           return null;
         },
         "PATCH /api/v1/drafts/{claimId}");
-    patchDraftClaim(claimId, claim);
   }
 
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public void deleteAllEvidenceFromClaim(UUID claimId) {
     Claim claim = getClaim(claimId);
     claim.setEvidence(new ArrayList<>());

--- a/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimService.java
+++ b/claim-for-payment-service/src/main/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimService.java
@@ -8,7 +8,10 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.justice.laa.claimforpayment.api.DraftClaimPayloadDeserializer;
 import uk.gov.justice.laa.claimforpayment.api.UploadFile;
 import uk.gov.justice.laa.claimforpayment.civilclaims.api.CivilDraftClaimsApi;
@@ -44,6 +47,9 @@ public class DraftClaimService implements ClaimServiceInterface {
   }
 
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public UUID addEvidenceToClaim(UUID claimId, UploadFile uploadFile) {
     Claim claim = getClaim(claimId);
     ClaimEvidence claimEvidence =
@@ -88,6 +94,9 @@ public class DraftClaimService implements ClaimServiceInterface {
   }
 
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public void deleteEvidenceFromClaim(UUID claimId, UUID evidenceId) {
     Claim claim = getClaim(claimId);
     ClaimEvidence claimEvidence = getClaimEvidenceOrThrow(claim, evidenceId);
@@ -97,7 +106,8 @@ public class DraftClaimService implements ClaimServiceInterface {
     civilDraftClaimPatch.setPayload(DraftClaimPayloadDeserializer.serialise(claim, claimId));
     executeCivilClaimsApi(
         () -> {
-          civilDraftClaimsApi.patchDraftClaim(claimId, civilDraftClaimPatch);
+          civilDraftClaimsApi.patchDraftClaim(
+              claimId, String.valueOf(claim.getVersion()), civilDraftClaimPatch);
           return null;
         },
         "PATCH /api/v1/drafts/{claimId}");
@@ -110,7 +120,9 @@ public class DraftClaimService implements ClaimServiceInterface {
             () -> civilDraftClaimsApi.getDraftClaim(claimId), "GET /api/v1/drafts/{claimId}");
 
     try {
-      return DraftClaimPayloadDeserializer.deserialise(draftClaim);
+      var deserialisedClaim = DraftClaimPayloadDeserializer.deserialise(draftClaim);
+      deserialisedClaim.setVersion(draftClaim.getVersion());
+      return deserialisedClaim;
     } catch (Exception e) {
       throw new UpstreamServiceException("Draft Claims API", "call", e);
     }
@@ -162,6 +174,9 @@ public class DraftClaimService implements ClaimServiceInterface {
   }
 
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public UUID addLineItemToClaim(UUID claimId, LineItemRequestBody lineItemRequestBody) {
     LineItem lineItem =
         LineItem.builder()
@@ -187,18 +202,10 @@ public class DraftClaimService implements ClaimServiceInterface {
     return lineItem.getId();
   }
 
-  private void patchDraftClaim(UUID claimId, Claim claim) {
-    CivilDraftClaimPatch civilDraftClaimPatch = new CivilDraftClaimPatch();
-    civilDraftClaimPatch.setPayload(DraftClaimPayloadDeserializer.serialise(claim, claimId));
-    executeCivilClaimsApi(
-        () -> {
-          civilDraftClaimsApi.patchDraftClaim(claimId, civilDraftClaimPatch);
-          return null;
-        },
-        "PATCH /api/v1/drafts/{claimId}");
-  }
-
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public void updateLineItem(
       UUID claimId, UUID lineItemId, LineItemRequestBody lineItemRequestBody) {
     Claim claim = getClaim(claimId);
@@ -217,13 +224,17 @@ public class DraftClaimService implements ClaimServiceInterface {
     civilDraftClaimPatch.setPayload(DraftClaimPayloadDeserializer.serialise(claim, claimId));
     executeCivilClaimsApi(
         () -> {
-          civilDraftClaimsApi.patchDraftClaim(claimId, civilDraftClaimPatch);
+          civilDraftClaimsApi.patchDraftClaim(
+              claimId, String.valueOf(claim.getVersion()), civilDraftClaimPatch);
           return null;
         },
         "PATCH /api/v1/drafts/{claimId}");
   }
 
   @Override
+  @Retryable(
+      retryFor = HttpClientErrorException.Conflict.class,
+      backoff = @Backoff(delay = 100, maxDelay = 500, multiplier = 2.0))
   public void deleteLineItem(UUID claimId, UUID lineItemId) {
     Claim claim = getClaim(claimId);
     LineItem lineItem = getLineItemOrThrow(claim, lineItemId);
@@ -233,7 +244,20 @@ public class DraftClaimService implements ClaimServiceInterface {
     civilDraftClaimPatch.setPayload(DraftClaimPayloadDeserializer.serialise(claim, claimId));
     executeCivilClaimsApi(
         () -> {
-          civilDraftClaimsApi.patchDraftClaim(claimId, civilDraftClaimPatch);
+          civilDraftClaimsApi.patchDraftClaim(
+              claimId, String.valueOf(claim.getVersion()), civilDraftClaimPatch);
+          return null;
+        },
+        "PATCH /api/v1/drafts/{claimId}");
+  }
+
+  private void patchDraftClaim(UUID claimId, Claim claim) {
+    CivilDraftClaimPatch civilDraftClaimPatch = new CivilDraftClaimPatch();
+    civilDraftClaimPatch.setPayload(DraftClaimPayloadDeserializer.serialise(claim, claimId));
+    executeCivilClaimsApi(
+        () -> {
+          civilDraftClaimsApi.patchDraftClaim(
+              claimId, String.valueOf(claim.getVersion()), civilDraftClaimPatch);
           return null;
         },
         "PATCH /api/v1/drafts/{claimId}");

--- a/claim-for-payment-service/src/main/openapi/stub-civil-claims-api.json
+++ b/claim-for-payment-service/src/main/openapi/stub-civil-claims-api.json
@@ -148,6 +148,14 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -754,8 +762,15 @@
         "properties": {
           "payload": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": {
+
+            },
             "description": "payload"
+          },
+          "version": {
+            "type": "integer",
+            "format": "int64",
+            "description": "version"
           },
           "providerUserId": {
             "type": "string",
@@ -765,7 +780,8 @@
         },
         "required": [
           "payload",
-          "providerUserId"
+          "providerUserId",
+          "version"
         ]
       },
       "ClaimRequestBody": {
@@ -827,7 +843,9 @@
           },
           "payload": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": {
+
+            },
             "description": "payload"
           },
           "providerUserId": {
@@ -866,7 +884,9 @@
         "properties": {
           "payload": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": {
+
+            },
             "description": "payload"
           }
         }
@@ -874,13 +894,19 @@
       "DraftClaim": {
         "type": "object",
         "properties": {
+          "version": {
+            "type": "integer",
+            "format": "int64"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
           },
           "payload": {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": {
+
+            },
             "description": "payload"
           },
           "providerUserId": {
@@ -890,7 +916,8 @@
           }
         },
         "required": [
-          "id"
+          "id",
+          "version"
         ]
       },
       "LineItemRequestBody": {

--- a/claim-for-payment-service/src/test/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimServiceTest.java
+++ b/claim-for-payment-service/src/test/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimServiceTest.java
@@ -624,10 +624,11 @@ public class DraftClaimServiceTest {
     civilDraftClaim.setId(DRAFT_ID);
     civilDraftClaim.setPayload(payload);
     civilDraftClaim.setProviderUserId(PROVIDER_USER_ID);
+    civilDraftClaim.setVersion(0L);
 
     when(mockDraftCivilClaimsApi.getDraftClaim(DRAFT_ID)).thenReturn(civilDraftClaim);
     draftClaimService.deleteAllEvidenceFromClaim(DRAFT_ID);
 
-    verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(DRAFT_ID), any(CivilDraftClaimPatch.class));
+    verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(DRAFT_ID), eq(String.valueOf(civilDraftClaim.getVersion())), any(CivilDraftClaimPatch.class));
   }
 }

--- a/claim-for-payment-service/src/test/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimServiceTest.java
+++ b/claim-for-payment-service/src/test/java/uk/gov/justice/laa/claimforpayment/service/DraftClaimServiceTest.java
@@ -3,10 +3,12 @@ package uk.gov.justice.laa.claimforpayment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,11 +24,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.justice.laa.claimforpayment.api.UploadFile;
 import uk.gov.justice.laa.claimforpayment.civilclaims.api.CivilDraftClaimsApi;
@@ -43,12 +49,18 @@ import uk.gov.justice.laa.claimforpayment.model.LineItemRequestBody;
  * and delete draft claims, as well as to manage evidence associated with those claims. It interacts
  * with the CivilDraftClaimsApi to perform operations on draft claims.
  */
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {DraftClaimServiceTest.TestConfig.class, DraftClaimService.class})
 public class DraftClaimServiceTest {
 
-  @Mock private CivilDraftClaimsApi mockDraftCivilClaimsApi;
+  @Configuration
+  @EnableRetry(proxyTargetClass = true)
+  static class TestConfig {}
 
-  @InjectMocks private DraftClaimService draftClaimService;
+  @MockitoBean // Use @MockBean for Spring Boot <= 3.3
+  private CivilDraftClaimsApi mockDraftCivilClaimsApi;
+
+  @Autowired private DraftClaimService draftClaimService;
 
   private static final UUID DRAFT_ID = UUID.randomUUID();
   private static final UUID PROVIDER_USER_ID = UUID.randomUUID();
@@ -307,6 +319,7 @@ public class DraftClaimServiceTest {
     civilDraftClaim.setId(DRAFT_ID);
     civilDraftClaim.setPayload(payload);
     civilDraftClaim.setProviderUserId(PROVIDER_USER_ID);
+    civilDraftClaim.setVersion(0L);
 
     LineItemRequestBody lineItemRequestBody =
         LineItemRequestBody.builder()
@@ -333,7 +346,9 @@ public class DraftClaimServiceTest {
       ArgumentCaptor<CivilDraftClaimPatch> captor =
           ArgumentCaptor.forClass(CivilDraftClaimPatch.class);
 
-      verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(DRAFT_ID), captor.capture());
+      verify(mockDraftCivilClaimsApi)
+          .patchDraftClaim(
+              eq(DRAFT_ID), eq(String.valueOf(civilDraftClaim.getVersion())), captor.capture());
 
       assertThat(captor.getValue().getPayload())
           .containsEntry("id", DRAFT_ID)
@@ -393,7 +408,11 @@ public class DraftClaimServiceTest {
 
     draftClaimService.updateLineItem(claimId, lineItemId, lineItemRequestBody);
 
-    verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(claimId), any(CivilDraftClaimPatch.class));
+    verify(mockDraftCivilClaimsApi)
+        .patchDraftClaim(
+            eq(claimId),
+            eq(String.valueOf(civilDraftClaim.getVersion())),
+            any(CivilDraftClaimPatch.class));
   }
 
   @Test
@@ -449,12 +468,17 @@ public class DraftClaimServiceTest {
     civilDraftClaim.setId(claimId);
     civilDraftClaim.setPayload(payload);
     civilDraftClaim.setProviderUserId(PROVIDER_USER_ID);
+    civilDraftClaim.setVersion(0L);
 
     when(mockDraftCivilClaimsApi.getDraftClaim(claimId)).thenReturn(civilDraftClaim);
 
     draftClaimService.deleteLineItem(claimId, lineItemId);
 
-    verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(claimId), any(CivilDraftClaimPatch.class));
+    verify(mockDraftCivilClaimsApi)
+        .patchDraftClaim(
+            eq(claimId),
+            eq(String.valueOf(civilDraftClaim.getVersion())),
+            any(CivilDraftClaimPatch.class));
   }
 
   @Test
@@ -470,6 +494,7 @@ public class DraftClaimServiceTest {
     civilDraftClaim.setId(DRAFT_ID);
     civilDraftClaim.setPayload(payload);
     civilDraftClaim.setProviderUserId(PROVIDER_USER_ID);
+    civilDraftClaim.setVersion(0L);
 
     when(mockDraftCivilClaimsApi.getDraftClaim(DRAFT_ID)).thenReturn(civilDraftClaim);
     TimeBasedEpochGenerator generator = mock(TimeBasedEpochGenerator.class);
@@ -483,7 +508,9 @@ public class DraftClaimServiceTest {
       ArgumentCaptor<CivilDraftClaimPatch> captor =
           ArgumentCaptor.forClass(CivilDraftClaimPatch.class);
 
-      verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(DRAFT_ID), captor.capture());
+      verify(mockDraftCivilClaimsApi)
+          .patchDraftClaim(
+              eq(DRAFT_ID), eq(String.valueOf(civilDraftClaim.getVersion())), captor.capture());
 
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> evidence =
@@ -500,6 +527,60 @@ public class DraftClaimServiceTest {
   }
 
   @Test
+  @DisplayName("Should retry when patchDraftClaim encounters 409 conflict and succeed")
+  void shouldRetryWhenPatchDraftClaimFailsWithConflict() {
+    UploadFile uploadFile = new UploadFile("test.pdf", 100L);
+
+    // Prepare initial claim (version 0)
+    Map<String, Object> initialPayload = new HashMap<>();
+    initialPayload.put("id", DRAFT_ID);
+    initialPayload.put("providerUserId", PROVIDER_USER_ID);
+
+    CivilDraftClaim claimV0 = new CivilDraftClaim();
+    claimV0.setId(DRAFT_ID);
+    claimV0.setPayload(initialPayload);
+    claimV0.setProviderUserId(PROVIDER_USER_ID);
+    claimV0.setVersion(0L);
+
+    // Prepare updated claim for second attempt (version 1)
+    Map<String, Object> updatedPayload = new HashMap<>(initialPayload);
+    CivilDraftClaim claimV1 = new CivilDraftClaim();
+    claimV1.setId(DRAFT_ID);
+    claimV1.setPayload(updatedPayload);
+    claimV1.setProviderUserId(PROVIDER_USER_ID);
+    claimV1.setVersion(1L);
+
+    // Return version 0 on first call, version 1 on second call
+    when(mockDraftCivilClaimsApi.getDraftClaim(DRAFT_ID)).thenReturn(claimV0).thenReturn(claimV1);
+
+    doThrow(
+            HttpClientErrorException.Conflict.create(
+                HttpStatus.CONFLICT, "Conflict", HttpHeaders.EMPTY, new byte[0], null))
+        .doReturn(new CivilDraftClaim()) // or doReturn(null)
+        .when(mockDraftCivilClaimsApi)
+        .patchDraftClaim(eq(DRAFT_ID), anyString(), any(CivilDraftClaimPatch.class));
+
+    TimeBasedEpochGenerator generator = mock(TimeBasedEpochGenerator.class);
+    when(generator.generate()).thenReturn(EVIDENCE_ID);
+
+    try (MockedStatic<Generators> mocked = mockStatic(Generators.class)) {
+      mocked.when(Generators::timeBasedEpochGenerator).thenReturn(generator);
+
+      // Call method under test
+      draftClaimService.addEvidenceToClaim(DRAFT_ID, uploadFile);
+
+      // Verify getDraftClaim was called twice
+      verify(mockDraftCivilClaimsApi, times(2)).getDraftClaim(DRAFT_ID);
+
+      // Verify patchDraftClaim was called twice: first with version "0", then with version "1"
+      verify(mockDraftCivilClaimsApi)
+          .patchDraftClaim(eq(DRAFT_ID), eq("0"), any(CivilDraftClaimPatch.class));
+      verify(mockDraftCivilClaimsApi)
+          .patchDraftClaim(eq(DRAFT_ID), eq("1"), any(CivilDraftClaimPatch.class));
+    }
+  }
+
+  @Test
   @DisplayName("Should delete evidence from draft claim")
   void shouldDeleteEvidenceFromDraftClaim() {
 
@@ -511,15 +592,18 @@ public class DraftClaimServiceTest {
         "evidence",
         List.of(Map.of("fileKey", "filekey", "fileSize", 100L, "id", EVIDENCE_ID.toString())));
 
-
     CivilDraftClaim civilDraftClaim = new CivilDraftClaim();
     civilDraftClaim.setId(DRAFT_ID);
     civilDraftClaim.setPayload(payload);
     civilDraftClaim.setProviderUserId(PROVIDER_USER_ID);
-
+    civilDraftClaim.setVersion(0L);
     when(mockDraftCivilClaimsApi.getDraftClaim(DRAFT_ID)).thenReturn(civilDraftClaim);
     draftClaimService.deleteEvidenceFromClaim(DRAFT_ID, EVIDENCE_ID);
 
-    verify(mockDraftCivilClaimsApi).patchDraftClaim(eq(DRAFT_ID), any(CivilDraftClaimPatch.class));
+    verify(mockDraftCivilClaimsApi)
+        .patchDraftClaim(
+            eq(DRAFT_ID),
+            eq(String.valueOf(civilDraftClaim.getVersion())),
+            any(CivilDraftClaimPatch.class));
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/CLAS-755)

- Draft Claim contains version (not returned by the API)
- Added Spring AOP Retry/backoff logic (3 times max with increasing backoff)

We can fiddle around with the backoff settings.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
